### PR TITLE
Updated for 4.17

### DIFF
--- a/CashGen.uplugin
+++ b/CashGen.uplugin
@@ -21,4 +21,14 @@
 			"LoadingPhase": "Default"
 		}
 	]
+	"Plugins": [
+		{
+			"Name": "RuntimeMeshComponent",
+			"Enabled": true
+		},
+		{
+			"Name": "UnrealFastNoisePlugin",
+			"Enabled": true
+		}
+	]	
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # cashgenUE
-Procedural Terrain Generator for UnrealEngine 4.15
+Procedural Terrain Generator for UnrealEngine 4.17
 
 This plugin generates heightmap-based terrain tiles in realtime, and move the tiles around to track a player pawn. 
 

--- a/Source/CashGen/Public/Struct/CGJob.h
+++ b/Source/CashGen/Public/Struct/CGJob.h
@@ -5,7 +5,7 @@
 class ACGTile;
 struct FCGMeshData;
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct FCGJob
 {
 	GENERATED_USTRUCT_BODY()

--- a/Source/CashGen/Public/Struct/CGLODConfig.h
+++ b/Source/CashGen/Public/Struct/CGLODConfig.h
@@ -2,7 +2,7 @@
 #pragma once
 #include "CGLODConfig.generated.h"
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct FCGLODConfig
 {
 	GENERATED_USTRUCT_BODY()

--- a/Source/CashGen/Public/Struct/CGLODMeshData.h
+++ b/Source/CashGen/Public/Struct/CGLODMeshData.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "CGLODMeshData.generated.h"
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct FCGLODMeshData
 {
 	GENERATED_USTRUCT_BODY()

--- a/Source/CashGen/Public/Struct/CGMeshData.h
+++ b/Source/CashGen/Public/Struct/CGMeshData.h
@@ -5,7 +5,7 @@
 #include "CGMeshdata.generated.h"
 
 /** Defines the data required for a single procedural mesh section */
-USTRUCT()
+USTRUCT(BlueprintType)
 struct FCGMeshData
 {
 	GENERATED_USTRUCT_BODY()

--- a/Source/CashGen/Public/Struct/CGTerrainConfig.h
+++ b/Source/CashGen/Public/Struct/CGTerrainConfig.h
@@ -7,7 +7,7 @@
 
 
 /** Struct defines all applicable attributes for managing generation of a single zone */
-USTRUCT()
+USTRUCT(BlueprintType)
 struct FCGTerrainConfig
 {
 	GENERATED_USTRUCT_BODY()

--- a/Source/CashGen/Public/Struct/CGWorldConfig.h
+++ b/Source/CashGen/Public/Struct/CGWorldConfig.h
@@ -5,7 +5,7 @@
 
 
 /** Struct defines all applicable attributes for managing generation of a single world */
-USTRUCT()
+USTRUCT(BlueprintType)
 struct FCGWorldConfig
 {
 	GENERATED_USTRUCT_BODY()

--- a/Source/CashGen/Public/Struct/CGWorldFaceJob.h
+++ b/Source/CashGen/Public/Struct/CGWorldFaceJob.h
@@ -5,7 +5,7 @@
 class ACGWorldFace;
 struct FCGWorldMeshData;
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct FCGWorldFaceJob
 {
 	GENERATED_USTRUCT_BODY()

--- a/Source/CashGen/cashgen.Build.cs
+++ b/Source/CashGen/cashgen.Build.cs
@@ -4,8 +4,8 @@ using UnrealBuildTool;
 
 public class CashGen : ModuleRules
 {
-	public CashGen(TargetInfo Target)
-	{
+	public CashGen(ReadOnlyTargetRules Target) : base(Target)
+    {
         
 		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore"  });
         PublicDependencyModuleNames.AddRange(new string[] { "ShaderCore", "RenderCore", "RHI", "RuntimeMeshComponent" });


### PR DESCRIPTION
I just updated the Build.cs for the new (ReadOnlyTargetRules Target) : base(Target) syntax that was causing warnings during compile > 4.15 and they started requiring the passing of "BlueprintType" in the USTRUCT declaration for exposing structs to blueprints in 4.17.  Nothing major.

I also made the changes in Build.cs for the UnrealFastNoise but it's just that one small change.  I can create a pull request for that too if you want. 

Cheers,
Donnie