### PR TITLE
Delete FRunningThread instances

### DIFF
--- a/Source/CashGen/Private/CGTerrainManager.cpp
+++ b/Source/CashGen/Private/CGTerrainManager.cpp
@@ -51,6 +51,7 @@ void ACGTerrainManager::BeginDestroy()
 		{
 			thread->Kill();
 			delete thread;
+			thread = nullptr;
 		}
 	}
 

--- a/Source/CashGen/Private/CGTerrainManager.cpp
+++ b/Source/CashGen/Private/CGTerrainManager.cpp
@@ -1,5 +1,6 @@
 
 #include "CGTerrainManager.h"
+#include "CGTerrainGeneratorWorker.h"
 #include "CGTile.h"
 #include "CGTileHandle.h"
 #include "CGJob.h"
@@ -49,6 +50,7 @@ void ACGTerrainManager::BeginDestroy()
 		if (thread != nullptr)
 		{
 			thread->Kill();
+			delete thread;
 		}
 	}
 


### PR DESCRIPTION
If I understood the API correctly, FRunningThread instances aren't garbage collected and should be deleted. I didn't find much information on it online, only this: https://answers.unrealengine.com/questions/587848/how-to-use-the-frunnable.html

Also, as experimental proof, (1) adding that one delete doesn't cause the engine to crash, but (2) if I duplicate it (i.e. call delete twice in a row), then it crashes. So (2) implies that deleting something that you weren't supposed to delete does crash and together with (1) that indicates that FRunningThread instances are supposed to be deleted. This is not proof though, they might still be garbage collected somewhere.

Furthermore, adding the include toCGTerrainGeneratorWorker.h was necessary for me to make this build without errors. Probably because we're creating instances of it in this .cpp file.