### PR TITLE
Fix OnTerrainComplete event

### DIFF
--- a/Source/CashGen/Private/CGTerrainManager.cpp
+++ b/Source/CashGen/Private/CGTerrainManager.cpp
@@ -200,8 +200,17 @@ void ACGTerrainManager::Tick(float DeltaSeconds)
 		    myPendingJobQueue.IsEmpty() &&
 			myUpdateJobQueue.IsEmpty())
 	{
-		BroadcastTerrainComplete();
-		myIsTerrainComplete = true;
+		bool hasJobsInProgress = false;
+		for (auto& queue : myGeometryJobQueues) {
+			if (!queue.IsEmpty()) {
+				hasJobsInProgress = true;
+				break;
+			}
+		}
+		if (!hasJobsInProgress) {
+			BroadcastTerrainComplete();
+			myIsTerrainComplete = true;
+		}
 	}
 }
 


### PR DESCRIPTION
In the beginning, all jobs are pushed to the pending queue, and then from there onto the geometry queue. As long as they're in the geometry queue, the terrain isn't complete yet, so we have to check these queues too.