### PR TITLE
Better thread utilization

### DIFF
--- a/Source/CashGen/Private/CGTerrainManager.cpp
+++ b/Source/CashGen/Private/CGTerrainManager.cpp
@@ -73,13 +73,21 @@ void ACGTerrainManager::Tick(float DeltaSeconds)
 		FCGJob pendingJob;
 		if (myPendingJobQueue.Peek(pendingJob))
 		{
-			// If there's free data to allocate, dequeue and send to worker thread
-			if (myFreeMeshData[pendingJob.LOD].Num() > 0)
-			{
-				myPendingJobQueue.Dequeue(pendingJob);
-				GetFreeMeshData(pendingJob);
-				myGeometryJobQueues[i].Enqueue(pendingJob);
+			// Skip if there's no free data to allocate
+			if (myFreeMeshData[pendingJob.LOD].Num() == 0) {
+				continue;
 			}
+			
+			// Skip if the worker thread already has a pending job
+			// (this allows better thread utilization in case another worker is free)
+			if (!myGeometryJobQueues[i].IsEmpty()) {
+				continue;
+			}
+			
+			// Dequeue and send to worker thread
+			myPendingJobQueue.Dequeue(pendingJob);
+			GetFreeMeshData(pendingJob);
+			myGeometryJobQueues[i].Enqueue(pendingJob);
 		}
 	}
 


### PR DESCRIPTION
The current behavior equally distributes work among all worker threads. If one thread is finished faster than others, it would idle while the work queues of other threads might still be full. This PR changes it so that the per-thread queues have at most one element and most jobs are kept in `myPendingJobQueue`, where they are automatically given to the first thread that is idle.