### PR TITLE
Improve concurrency and reliability

### DIFF
--- a/Source/CashGen/Private/CGMCQueue.cpp
+++ b/Source/CashGen/Private/CGMCQueue.cpp
@@ -1,0 +1,1 @@
+#include "CGMcQueue.h"

--- a/Source/CashGen/Private/CGObjectPool.cpp
+++ b/Source/CashGen/Private/CGObjectPool.cpp
@@ -1,0 +1,1 @@
+#include "CGObjectPool.h"

--- a/Source/CashGen/Private/CGTerrainGeneratorWorker.cpp
+++ b/Source/CashGen/Private/CGTerrainGeneratorWorker.cpp
@@ -42,7 +42,7 @@ uint32 FCGTerrainGeneratorWorker::Run()
 				workJob.Data = (*pMeshDataPoolsPerLOD)[workLOD].Borrow([&] {return !IsThreadFinished; });
 			} catch (const std::exception&) {
 				if (IsThreadFinished) {
-					// seems borrowing aborted because sIsThreadFinished got true. Let's just return
+					// seems borrowing aborted because IsThreadFinished got true. Let's just return
 					return 1;
 				}
 				// and in any other case, rethrow

--- a/Source/CashGen/Private/CGTerrainManager.cpp
+++ b/Source/CashGen/Private/CGTerrainManager.cpp
@@ -34,10 +34,8 @@ void ACGTerrainManager::BeginPlay()
 
 	for (int i = 0; i < myTerrainConfig.NumberOfThreads; i++)
 	{
-		myGeometryJobQueues.Emplace();
-
 		myWorkerThreads.Add(FRunnableThread::Create
-		(new FCGTerrainGeneratorWorker(this, &myTerrainConfig, &myGeometryJobQueues[i]),
+		(new FCGTerrainGeneratorWorker(this, &myTerrainConfig, &myFreeMeshData),
 			*threadName,
 			0, EThreadPriority::TPri_Normal, FPlatformAffinity::GetNoAffinityMask()));
 	}
@@ -68,30 +66,6 @@ void ACGTerrainManager::Tick(float DeltaSeconds)
 	if (myTerrainConfig.NumberOfThreads > FPlatformMisc::NumberOfCores())
 	{
 		myTerrainConfig.NumberOfThreads = FPlatformMisc::NumberOfCores();
-	}
-
-	// Check for pending jobs
-	for (int i = 0; i < myTerrainConfig.NumberOfThreads; i++)
-	{
-		FCGJob pendingJob;
-		if (myPendingJobQueue.Peek(pendingJob))
-		{
-			// Skip if there's no free data to allocate
-			if (myFreeMeshData[pendingJob.LOD].Num() == 0) {
-				continue;
-			}
-			
-			// Skip if the worker thread already has a pending job
-			// (this allows better thread utilization in case another worker is free)
-			if (!myGeometryJobQueues[i].IsEmpty()) {
-				continue;
-			}
-			
-			// Dequeue and send to worker thread
-			myPendingJobQueue.Dequeue(pendingJob);
-			GetFreeMeshData(pendingJob);
-			myGeometryJobQueues[i].Enqueue(pendingJob);
-		}
 	}
 
 	// Now check for Update jobs
@@ -129,7 +103,7 @@ void ACGTerrainManager::Tick(float DeltaSeconds)
 				GEngine->AddOnScreenDebugMessage(2, 5.f, FColor::Red, TEXT("MeshUpdate " + FString::FromInt(updateMS) + "ms"));
 			}
 #endif
-			ReleaseMeshData(updateJob.LOD, updateJob.Data);
+			updateJob.Data.Release();
 			myQueuedSectors.Remove(updateJob.mySector);
 		}
 	}
@@ -211,17 +185,8 @@ void ACGTerrainManager::Tick(float DeltaSeconds)
 		    myPendingJobQueue.IsEmpty() &&
 			myUpdateJobQueue.IsEmpty())
 	{
-		bool hasJobsInProgress = false;
-		for (auto& queue : myGeometryJobQueues) {
-			if (!queue.IsEmpty()) {
-				hasJobsInProgress = true;
-				break;
-			}
-		}
-		if (!hasJobsInProgress) {
-			BroadcastTerrainComplete();
-			myIsTerrainComplete = true;
-		}
+		BroadcastTerrainComplete();
+		myIsTerrainComplete = true;
 	}
 }
 
@@ -366,8 +331,8 @@ void ACGTerrainManager::CreateTileRefreshJob(FCGJob aJob)
 {
 	if (aJob.LOD != 10)
 	{
-		myPendingJobQueue.Enqueue(aJob);
 		myQueuedSectors.Add(aJob.mySector);
+		myPendingJobQueue.Enqueue(std::move(aJob));
 	}
 
 }
@@ -428,36 +393,9 @@ void ACGTerrainManager::ProcessTilesForActor(const AActor* anActor)
 				}
 			}
 
-			CreateTileRefreshJob(job);
+			CreateTileRefreshJob(std::move(job));
 		}
 	}
-}
-
-bool ACGTerrainManager::GetFreeMeshData(FCGJob& aJob)
-{
-	// No free mesh data
-	if (myFreeMeshData[aJob.LOD].Num() < 1)
-	{
-		return false;
-	}
-	else
-	{
-		// Use the first free data set, there'll always be one, we checked!
-		FCGMeshData* dataToUse = *myFreeMeshData[aJob.LOD].begin();
-		
-		// Remove from the Free set
-		myFreeMeshData[aJob.LOD].Remove(dataToUse);
-
-		aJob.Data = dataToUse;
-		return true;
-	}
-
-	return false;
-}
-
-void ACGTerrainManager::ReleaseMeshData(uint8 aLOD, FCGMeshData* aDataToRelease)
-{
-	myFreeMeshData[aLOD].Add(aDataToRelease);
 }
 
 /** Allocates data structures and pointers for mesh data **/
@@ -466,7 +404,7 @@ void ACGTerrainManager::AllocateAllMeshDataStructures()
 	for (uint8 lod = 0; lod < myTerrainConfig.LODs.Num(); ++lod)
 	{
 		myMeshData.Add(FCGLODMeshData());
-		myFreeMeshData.Add(TSet<FCGMeshData*>());
+		myFreeMeshData.Emplace();
 
 		myMeshData[lod].Data.Reserve(myTerrainConfig.MeshDataPoolSize);
 

--- a/Source/CashGen/Private/CGTile.cpp
+++ b/Source/CashGen/Private/CGTile.cpp
@@ -157,7 +157,7 @@ void ACGTile::UpdateSettings(FIntVector2 aOffset, FCGTerrainConfig* aTerrainConf
 		{
 			myTexture = UTexture2D::CreateTransient(TerrainConfigMaster->TileXUnits, TerrainConfigMaster->TileYUnits, EPixelFormat::PF_B8G8R8A8);
 			myTexture->AddressX = TA_Clamp;
-+                       myTexture->AddressY = TA_Clamp;
+            myTexture->AddressY = TA_Clamp;
 
 			myTexture->UpdateResource();
 

--- a/Source/CashGen/Public/CGMCQueue.h
+++ b/Source/CashGen/Public/CGMCQueue.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <mutex>
+
+/**
+* A multi consumer threadsafe queue
+*/
+template<class T, EQueueMode BaseQueueMode>
+class TCGMcQueueBase final {
+public:
+	void Enqueue(T&& job) {
+		bool success = queue_.Enqueue(std::move(job));
+		check(success);
+	}
+
+	bool Dequeue(T& job) {
+		// TQueue is not threadsafe for multiple consumers. We need to serialize consumers using a lock.
+		// There is more performant implementations of MC queues, but we don't plan to use this queue
+		// on a perf critical path.
+		std::lock_guard<std::mutex> lock(consumerMutex_);
+		return queue_.Dequeue(job);
+	}
+
+	bool IsEmpty() const {
+		return queue_.IsEmpty();
+	}
+
+private:
+	std::mutex consumerMutex_;
+	TQueue<T, BaseQueueMode> queue_;
+};
+
+/**
+* A multi producer multi consumer threadsafe queue.
+*/
+template<class T> using TCGMpmcQueue = TCGMcQueueBase<T, EQueueMode::Mpsc>;
+
+/**
+* A single producer multi consumer threadsafe queue.
+*/
+template<class T> using TCGSpmcQueue = TCGMcQueueBase<T, EQueueMode::Spsc>;

--- a/Source/CashGen/Public/CGObjectPool.h
+++ b/Source/CashGen/Public/CGObjectPool.h
@@ -1,0 +1,160 @@
+#pragma once
+
+#include <mutex>
+#include <vector>
+#include <condition_variable>
+
+template<class T> class TCGBorrowedObject;
+
+/**
+* A pool of objects that can be borrowed and returned.
+*
+* This class is threadsafe.
+* You can add and borrow objects from different threads concurrently.
+*/
+template<class T>
+class TCGObjectPool final {
+public:
+	/**
+	* Borrow an object from the pool. It will be removed from the pool
+	* and you can use it. Once the TCGBorrowedObject is destructed,
+	* it will automatically be put back into the object pool.
+	*
+	* If there is no object available in the pool, this will block
+	* until there is one available.
+	*/
+	TCGBorrowedObject<T> Borrow() {
+		std::unique_lock<std::mutex> lock(mutex_);
+		cv_.wait(lock, [&]() {
+			return !freeObjects_.empty();
+		});
+		TCGBorrowedObject<T> result(this, freeObjects_.back());
+		freeObjects_.pop_back();
+		return result;
+	}
+
+	/**
+	* Add a new object from the pool. After adding it, it can be borrowed.
+	*/
+	void Add(T* object) {
+		std::lock_guard<std::mutex> lock(mutex_);
+		freeObjects_.push_back(object);
+		cv_.notify_one();
+	}
+
+	TCGObjectPool() = default;
+
+	// copying and moving is forbidden because there might be objects
+	// borrowed from this pool that would then be put back into the wrong pool
+	TCGObjectPool(const TCGObjectPool&) = delete;
+	TCGObjectPool(TCGObjectPool&&) noexcept = delete;
+	TCGObjectPool& operator=(const TCGObjectPool&) = delete;
+	TCGObjectPool& operator=(TCGObjectPool&&) noexcept = delete;
+
+private:
+	std::mutex mutex_;
+	std::condition_variable cv_;
+	std::vector<T*> freeObjects_;
+};
+
+/**
+* A handle to an object borrowed from the object pool.
+* This class is *not* threadsafe. You cannot share TCGBorrowedObjects between threads.
+*/
+template<class T>
+class TCGBorrowedObject final {
+public:
+	/**
+	* Get a pointer to the borrowed object.
+	*/
+	T* Get() {
+		T* result = impl_->Get();
+		check(nullptr != result && "TCGBorrowedObject instance does not contain a borrowed object");
+		return result;
+	}
+
+	T* operator->() {
+		return Get();
+	}
+
+	/**
+	* Return true if this instance contains a valid object.
+	*/
+	bool IsValid() const {
+		return nullptr != impl_->Get();
+	}
+
+	/**
+	* Return the borrowed object to the pool.
+	*/
+	void Release() {
+		impl_->Release();
+	}
+
+	TCGBorrowedObject()
+		: impl_(std::make_shared<BorrowedObjectImpl>(nullptr, nullptr)) {
+	}
+
+private:
+	explicit TCGBorrowedObject(TCGObjectPool<T>* pool, T* object)
+		: impl_(std::make_shared<BorrowedObjectImpl>(pool, object)) {
+	}
+
+	class BorrowedObjectImpl final {
+	private:
+		TCGObjectPool<T>* pool_;
+		T* object_;
+	public:
+		T* Get() {
+			return object_;
+		}
+
+		explicit BorrowedObjectImpl(TCGObjectPool<T>* pool, T* object)
+			: pool_(pool), object_(object) {
+		}
+
+		/**
+		* Return the borrowed object to the pool.
+		*/
+		void Release() {
+			if (nullptr != object_) {
+				pool_->Add(object_);
+				pool_ = nullptr;
+				object_ = nullptr;
+			}
+			check(nullptr == pool_ && "Class invariant: If object_ is nullptr, so must be pool_.");
+		}
+
+		/**
+		* On destruction, we put the object back into the pool.
+		*/
+		~BorrowedObjectImpl() {
+			Release();
+		}
+
+		// copying is forbidden because it would break the RAII pattern of putting
+		// objects back into the pool.
+		BorrowedObjectImpl(const BorrowedObjectImpl&) = delete;
+		BorrowedObjectImpl& operator=(const BorrowedObjectImpl&) = delete;
+
+		BorrowedObjectImpl(BorrowedObjectImpl&& rhs) noexcept
+			: pool_(rhs.pool_), object_(rhs.object_) {
+			// make sure the old BorrowedObjectImpl doesn't put anything back into the pool
+			rhs.pool_ = nullptr;
+			rhs.object_ = nullptr;
+		}
+
+		BorrowedObjectImpl& operator=(BorrowedObjectImpl&& rhs) noexcept {
+			pool_ = rhs.pool_;
+			object_ = rhs.object_;
+			// make sure the old BorrowedObjectImpl doesn't put anything back into the pool
+			rhs.pool_ = nullptr;
+			rhs.object_ = nullptr;
+		}
+	};
+
+	// We use shared_ptr to get refcounting when TCGBorrowedObjects are copied around
+	std::shared_ptr<BorrowedObjectImpl> impl_;
+
+	friend class TCGObjectPool<T>;
+};

--- a/Source/CashGen/Public/CGTerrainGeneratorWorker.h
+++ b/Source/CashGen/Public/CGTerrainGeneratorWorker.h
@@ -11,7 +11,7 @@ class FCGTerrainGeneratorWorker : public FRunnable
 
 	ACGTerrainManager* pTerrainManager;
 	FCGTerrainConfig* pTerrainConfig;
-	TQueue<FCGJob, EQueueMode::Spsc>* inputQueue;
+	TArray<TCGObjectPool<FCGMeshData>>* pMeshDataPoolsPerLOD;
 	FCGJob workJob;
 	uint8 workLOD;
 
@@ -26,6 +26,7 @@ class FCGTerrainGeneratorWorker : public FRunnable
 	void ProcessPerBlockGeometry();
 	void ProcessPerVertexTasks();
 	void ProcessSkirtGeometry();
+	TCGBorrowedObject<FCGMeshData> BorrowMeshData();
 
 	void erodeHeightMapAtIndex(int32 aX, int32 aY, float aAmount);
 	void GetNormalFromHeightMapForVertex(const int32& vertexX, const int32& vertexY, FVector& aOutNormal);// , FVector& aOutTangent);
@@ -37,8 +38,7 @@ class FCGTerrainGeneratorWorker : public FRunnable
 public:
 
 	FCGTerrainGeneratorWorker(ACGTerrainManager* aTerrainManager,
-		FCGTerrainConfig* aTerrainConfig,
-		TQueue<FCGJob, EQueueMode::Spsc>* anInputQueue);
+		FCGTerrainConfig* aTerrainConfig, TArray<TCGObjectPool<FCGMeshData>>* meshDataPoolPerLOD);
 
 	virtual ~FCGTerrainGeneratorWorker();
 

--- a/Source/CashGen/Public/CGTerrainManager.h
+++ b/Source/CashGen/Public/CGTerrainManager.h
@@ -8,6 +8,8 @@
 #include "Struct/IntVector2.h"
 #include "Struct/CGSector.h"
 #include "CGSettings.h"
+#include "CGObjectPool.h"
+#include "CGMcQueue.h"
 #include "Struct/CGLODMeshData.h"
 #include "Components/HierarchicalInstancedStaticMeshComponent.h"
 #include "CGTerrainManager.generated.h"
@@ -45,6 +47,9 @@ public:
 	/* Add a new actor to track and generate terrain tiles around */
 	UFUNCTION(BlueprintCallable, Category = "CashGen")
 	void RemoveActorToTrack(AActor* aActor);
+
+	// Pending job queue, worker threads take jobs from here
+	TCGSpmcQueue<FCGJob> myPendingJobQueue;
 
 	// Update queue, jobs get sent here from the worker thread
 	TQueue<FCGJob, EQueueMode::Mpsc> myUpdateJobQueue;
@@ -85,12 +90,8 @@ private:
 
 	// Geometry data storage
 	UPROPERTY()
-	TArray<FCGLODMeshData>		myMeshData;
-	TArray<TSet<FCGMeshData*>>	myFreeMeshData;
-
-	// Job tracking
-	TQueue<FCGJob, EQueueMode::Spsc>			myPendingJobQueue;
-	TArray<TQueue<FCGJob, EQueueMode::Spsc>>	myGeometryJobQueues;
+	TArray<FCGLODMeshData>				myMeshData;
+	TArray<TCGObjectPool<FCGMeshData>>	myFreeMeshData;
 
 	// Tile/Sector tracking
 	TArray<ACGTile*>	myFreeTiles;
@@ -105,8 +106,6 @@ private:
 
 	bool myIsTerrainComplete = false;
 
-	bool GetFreeMeshData(FCGJob& aJob);
-	void ReleaseMeshData(uint8 aLOD, FCGMeshData* aDataToRelease);
 	void AllocateAllMeshDataStructures();
 	bool AllocateDataStructuresForLOD(FCGMeshData* aData, FCGTerrainConfig* aConfig, const uint8 aLOD);
 

--- a/Source/CashGen/Public/Struct/CGJob.h
+++ b/Source/CashGen/Public/Struct/CGJob.h
@@ -2,6 +2,7 @@
 #include "RuntimeMeshComponent.h"
 #include "Struct/IntVector2.h"
 #include "Struct/CGTileHandle.h"
+#include "CGObjectPool.h"
 #include "CGJob.generated.h"
 
 class ACGTile;
@@ -17,7 +18,7 @@ struct FCGJob
 	
 	FCGTileHandle myTileHandle;
 
-	FCGMeshData* Data;
+	TCGBorrowedObject<FCGMeshData> Data;
 
 	int32 HeightmapGenerationDuration;
 	int32 ErosionGenerationDuration;


### PR DESCRIPTION
This PR does a set of changes aimed at improving concurrency and reliability (mostly exception safety).

- Meshes are now kept in a `CGObjectPool`. If sombody borrows a mesh from the object pool and then dies with an exception, a RAII pattern will make sure that the mesh is returned to the pool and we don't leak it.
- Worker threads don't have individual queues anymore, but get jobs from the main pending job queue. This improves on https://github.com/midgen/cashgenUE/pull/41 and further increases thread utilization. For this, I introduced `TCGSpmcQueue` since the UE4 `TQueue` isn't threadsafe with multiple consumers.
- A side effect of this is that we don't do the job preparation (i.e. getting meshes and pushing jobs from the pending jobs queue to one of the worker input queues) on each tick anymore. Instead, worker threads get the meshes directly from the `CGObjectPool`.