### PR TITLE
Fix heightmap texture orientation

### DIFF
--- a/Source/CashGen/Private/CGTerrainGeneratorWorker.cpp
+++ b/Source/CashGen/Private/CGTerrainGeneratorWorker.cpp
@@ -136,9 +136,9 @@ void FCGTerrainGeneratorWorker::ProcessTerrainMap()
 	if (pTerrainConfig->GenerateSplatMap && workLOD == 0)
 	{
 		int i = 0;
-		for (int x = 0; x < pTerrainConfig->TileXUnits; ++x)
+		for (int y = 0; y < pTerrainConfig->TileYUnits; ++y)
 		{
-			for (int y = 0; y < pTerrainConfig->TileYUnits; ++y)
+			for (int x = 0; x < pTerrainConfig->TileXUnits; ++x)
 			{
 				float& noiseValue = pMeshData->HeightMap[(x + 1) + (exX*(y + 1))];
 


### PR DESCRIPTION
Before, the heightmap texture was built column-wise while the texture coordinates assumed it to be row-wise. This PR fixes that.

Can be tested by applying the height map texture in the material to the grid and see that it is now correct.