### PR TITLE
Clamp heightmap texture

### DIFF
--- a/Source/CashGen/Private/CGTile.cpp
+++ b/Source/CashGen/Private/CGTile.cpp
@@ -155,6 +155,8 @@ void ACGTile::UpdateSettings(FIntVector2 aOffset, FCGTerrainConfig* aTerrainConf
 		if (TerrainConfigMaster->GenerateSplatMap)
 		{
 			myTexture = UTexture2D::CreateTransient(TerrainConfigMaster->TileXUnits, TerrainConfigMaster->TileYUnits, EPixelFormat::PF_B8G8R8A8);
+			myTexture->AddressX = TA_Clamp;
++                       myTexture->AddressY = TA_Clamp;
 
 			myTexture->UpdateResource();
 


### PR DESCRIPTION
When using the heightmap texture somewhere, we don't want it to wrap around because that would cause weird artifacts at the tile borders.