### PR TITLE
OnAfterTileCreated Event

### DIFF
--- a/Source/CashGen/Private/CGTerrainManager.cpp
+++ b/Source/CashGen/Private/CGTerrainManager.cpp
@@ -130,6 +130,9 @@ void ACGTerrainManager::Tick(float DeltaSeconds)
 			}
 #endif
 			ReleaseMeshData(updateJob.LOD, updateJob.Data);
+			
+			OnAfterTileCreated(updateJob.myTileHandle.myHandle);
+			
 			myQueuedSectors.Remove(updateJob.mySector);
 		}
 	}

--- a/Source/CashGen/Public/CGTerrainManager.h
+++ b/Source/CashGen/Public/CGTerrainManager.h
@@ -60,6 +60,9 @@ public:
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "CashGen")
 	FCGTerrainConfig myTerrainConfig;
+	
+	UFUNCTION(BlueprintImplementableEvent, Category = "CashGen|Events")
+        void OnAfterTileCreated(ACGTile* tile);
 
 protected:
 	void BroadcastTerrainComplete()


### PR DESCRIPTION
This is an event that is called whenever a new tile is spawned.

Blueprints can connect to this to initialize the tile.