### PR TITLE
API macros

### DIFF
--- a/Source/CashGen/Public/CGSettings.h
+++ b/Source/CashGen/Public/CGSettings.h
@@ -7,7 +7,7 @@
 * Implements the settings for the CashGen Plugin
 */
 UCLASS(config = CashGen, BlueprintType)
-class UCGSettings : public UObject
+class CASHGEN_API UCGSettings : public UObject
 {
 	GENERATED_BODY()
 

--- a/Source/CashGen/Public/CGTerrainGeneratorWorker.h
+++ b/Source/CashGen/Public/CGTerrainGeneratorWorker.h
@@ -6,7 +6,7 @@
 
 struct FCGJob;
 
-class FCGTerrainGeneratorWorker : public FRunnable
+class CASHGEN_API FCGTerrainGeneratorWorker : public FRunnable
 {
 
 	ACGTerrainManager* pTerrainManager;

--- a/Source/CashGen/Public/CGTerrainManager.h
+++ b/Source/CashGen/Public/CGTerrainManager.h
@@ -15,7 +15,7 @@
 class ACGTile;
 
 UCLASS(BlueprintType, Blueprintable)
-class ACGTerrainManager : public AActor
+class CASHGEN_API ACGTerrainManager : public AActor
 {
 	GENERATED_BODY()
 

--- a/Source/CashGen/Public/CGTile.h
+++ b/Source/CashGen/Public/CGTile.h
@@ -13,7 +13,7 @@ class UStaticMeshComponent;
 enum ELODStatus { NOT_CREATED, CREATED, TRANSITION };
 
 UCLASS()
-class ACGTile : public AActor
+class CASHGEN_API ACGTile : public AActor
 {
 	GENERATED_BODY()
 

--- a/Source/CashGen/Public/CGWorld.h
+++ b/Source/CashGen/Public/CGWorld.h
@@ -11,7 +11,7 @@ class ACGWorldFace;
 struct FCGWorldFaceJob;
 
 UCLASS()
-class ACGWorld : public AActor
+class CASHGEN_API ACGWorld : public AActor
 {
 	GENERATED_BODY()
 

--- a/Source/CashGen/Public/CGWorldFace.h
+++ b/Source/CashGen/Public/CGWorldFace.h
@@ -9,7 +9,7 @@ class ACGWorldFace;
 class ACGWorld;
 
 UCLASS()
-class ACGWorldFace : public AActor
+class CASHGEN_API ACGWorldFace : public AActor
 {
 	GENERATED_BODY()
 

--- a/Source/CashGen/Public/CGWorldGeneratorWorker.h
+++ b/Source/CashGen/Public/CGWorldGeneratorWorker.h
@@ -7,7 +7,7 @@
 struct FCGWorldConfig;
 class ACGWorld;
 
-class FCGWorldGeneratorWorker : public FRunnable
+class CASHGEN_API FCGWorldGeneratorWorker : public FRunnable
 {
 	ACGWorld* pWorld;
 	TQueue<FCGWorldFaceJob, EQueueMode::Spsc>* inputQueue;

--- a/Source/CashGen/Public/CashGen.h
+++ b/Source/CashGen/Public/CashGen.h
@@ -8,7 +8,7 @@
 
 DECLARE_STATS_GROUP(TEXT("CashGen"), STATGROUP_CashGenStat, STATCAT_Advanced);
 
-class FCashGen : public IModuleInterface
+class CASHGEN_API FCashGen : public IModuleInterface
 {
 public:
 


### PR DESCRIPTION
These are necessary to make the build work correctly when any of these classes are used from C++ outside of their own module